### PR TITLE
Fix Mediapipe deprecation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ plexapi
 PyYAML
 requests
 Pillow
-mediapipe
+mediapipe == 0.10.5
 numpy
 opencv-python
 croniter


### PR DESCRIPTION
Mediapipe Solutions support was removed so latest version trigger an Error :

`AttributeError: module 'mediapipe' has no attribute 'solutions'`

This is temporary fix, support as moved to MediaPipe Tasks