### PR TITLE
feat: add Emby/Jellyfin support via adapter pattern + per-item apply/restore

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -1,6 +1,7 @@
-plex:
+server:
+  type: "plex"                        # plex | emby | jellyfin
   url: "http://your.plex.server:32400"
-  token: "your_plex_token"
+  token: "your_plex_token_or_emby_api_key"
   libraries:
     - "Movies"
     - "TV Shows"

--- a/docs/superpowers/plans/2026-04-01-per-item-apply-restore.md
+++ b/docs/superpowers/plans/2026-04-01-per-item-apply-restore.md
@@ -1,0 +1,336 @@
+# Per-Item Apply/Restore Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Apply and Restore buttons to each poster card in the web UI so a single item's prank poster can be pushed to or pulled from Emby immediately.
+
+**Architecture:** Two new Flask endpoints (`POST /api/items/<item_id>/apply` and `/restore`) handle the upload and DB status update. The web UI renders small action buttons inside each poster card that appear on hover, call the endpoints, and update the card's status badge inline without a page reload.
+
+**Tech Stack:** Python/Flask (backend), vanilla JS/HTML/CSS (frontend), SQLite (status tracking)
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `googlarr/web.py` | Add `api_item_apply` and `api_item_restore` endpoints |
+| `googlarr/web_ui.html` | Add CSS for action buttons + JS handlers + render buttons in poster cards |
+
+---
+
+## Task 1: Add backend endpoints to `web.py`
+
+**Files:**
+- Modify: `googlarr/web.py`
+
+- [ ] **Step 1: Add the two endpoints after `api_poster_prank` (around line 200)**
+
+Insert the following two functions into `googlarr/web.py`, after the `api_poster_prank` function and before `api_apply_now`:
+
+```python
+@app.route('/api/items/<item_id>/apply', methods=['POST'])
+def api_item_apply(item_id):
+    """Apply prank poster to a single item immediately."""
+    config = get_config()
+    db_path = get_db()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        c = conn.cursor()
+        c.execute("SELECT * FROM library_items WHERE item_id = ?", (item_id,))
+        item = c.fetchone()
+
+    if not item:
+        return jsonify({'success': False, 'error': 'Item not found'}), 404
+
+    item = dict(item)
+    prank_path = os.path.join(APP_ROOT, item['prank_path'])
+    if not os.path.exists(prank_path):
+        return jsonify({'success': False, 'error': 'Prank poster not generated yet'}), 400
+
+    try:
+        from googlarr.server import create_server
+        from googlarr.db import update_item_status
+        server = create_server(config)
+        server.upload_poster(item_id, prank_path)
+        update_item_status(db_path, item_id, 'PRANK_APPLIED')
+        return jsonify({'success': True, 'status': 'PRANK_APPLIED'})
+    except Exception as e:
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@app.route('/api/items/<item_id>/restore', methods=['POST'])
+def api_item_restore(item_id):
+    """Restore original poster for a single item immediately."""
+    config = get_config()
+    db_path = get_db()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        c = conn.cursor()
+        c.execute("SELECT * FROM library_items WHERE item_id = ?", (item_id,))
+        item = c.fetchone()
+
+    if not item:
+        return jsonify({'success': False, 'error': 'Item not found'}), 404
+
+    item = dict(item)
+    original_path = os.path.join(APP_ROOT, item['original_path'])
+    if not os.path.exists(original_path):
+        return jsonify({'success': False, 'error': 'Original poster not found'}), 400
+
+    try:
+        from googlarr.server import create_server
+        from googlarr.db import update_item_status
+        server = create_server(config)
+        server.upload_poster(item_id, original_path)
+        update_item_status(db_path, item_id, 'PRANK_GENERATED')
+        return jsonify({'success': True, 'status': 'PRANK_GENERATED'})
+    except Exception as e:
+        return jsonify({'success': False, 'error': str(e)}), 500
+```
+
+- [ ] **Step 2: Verify Flask can import with the new endpoints**
+
+```bash
+cd /home/jeremy/GitHub/JPT62089/googlarr
+python -c "from googlarr.web import app; print([r.rule for r in app.url_map.iter_rules() if 'items' in r.rule])"
+```
+
+Expected output:
+```
+['/api/items/<item_id>/apply', '/api/items/<item_id>/restore']
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add googlarr/web.py
+git commit -m "feat: add per-item apply/restore API endpoints"
+```
+
+---
+
+## Task 2: Add CSS for action buttons to `web_ui.html`
+
+**Files:**
+- Modify: `googlarr/web_ui.html`
+
+- [ ] **Step 1: Add CSS for the action buttons**
+
+Find the `.poster-status-prank-hover` CSS block (around line 299). Insert the following CSS block immediately after it (after the closing `}`):
+
+```css
+        .poster-item-actions {
+            position: absolute;
+            bottom: 28px;
+            left: 0; right: 0;
+            display: flex;
+            justify-content: center;
+            gap: 6px;
+            z-index: 5;
+            opacity: 0;
+            transition: opacity 0.2s ease;
+            padding: 0 6px;
+        }
+
+        .poster-item:hover .poster-item-actions {
+            opacity: 1;
+        }
+
+        .poster-action-btn {
+            font-size: 10px;
+            font-weight: 700;
+            padding: 3px 8px;
+            border: none;
+            border-radius: 3px;
+            cursor: pointer;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            white-space: nowrap;
+        }
+
+        .poster-action-btn.apply {
+            background: rgba(33, 150, 243, 0.92);
+            color: #fff;
+        }
+
+        .poster-action-btn.apply:hover {
+            background: rgba(33, 150, 243, 1);
+        }
+
+        .poster-action-btn.restore {
+            background: rgba(76, 175, 80, 0.92);
+            color: #fff;
+        }
+
+        .poster-action-btn.restore:hover {
+            background: rgba(76, 175, 80, 1);
+        }
+
+        .poster-action-btn:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add googlarr/web_ui.html
+git commit -m "feat: add CSS for per-item action buttons"
+```
+
+---
+
+## Task 3: Add JS handler and render buttons in poster cards
+
+**Files:**
+- Modify: `googlarr/web_ui.html`
+
+- [ ] **Step 1: Add the `itemAction` JS function**
+
+Find the `applyNow` function (around line 584). Insert the following function immediately before it:
+
+```javascript
+        async function itemAction(itemId, action, btn) {
+            btn.disabled = true;
+            const original = btn.textContent;
+            btn.textContent = '...';
+            try {
+                const resp = await fetch(`${API_BASE}/items/${itemId}/${action}`, { method: 'POST' });
+                const data = await resp.json();
+                if (data.success) {
+                    // Update the status badge on this card
+                    const card = btn.closest('.poster-item');
+                    const badge = card.querySelector('.poster-status');
+                    const statusConfig = {
+                        'PRANK_APPLIED':   { cls: 'status-prank-live',  label: 'Live' },
+                        'PRANK_GENERATED': { cls: 'status-prank-ready', label: 'Ready' },
+                    };
+                    const cfg = statusConfig[data.status];
+                    if (cfg && badge) {
+                        badge.className = `poster-status ${cfg.cls}`;
+                        badge.textContent = cfg.label;
+                    }
+                    // Swap which button is visible
+                    const actions = card.querySelector('.poster-item-actions');
+                    if (actions) {
+                        actions.innerHTML = '';
+                        if (data.status === 'PRANK_GENERATED') {
+                            actions.appendChild(makeActionBtn(itemId, 'apply', 'Apply'));
+                        } else if (data.status === 'PRANK_APPLIED') {
+                            actions.appendChild(makeActionBtn(itemId, 'restore', 'Restore'));
+                        }
+                    }
+                } else {
+                    btn.textContent = 'Error';
+                    setTimeout(() => { btn.disabled = false; btn.textContent = original; }, 2000);
+                }
+            } catch (e) {
+                btn.textContent = 'Error';
+                setTimeout(() => { btn.disabled = false; btn.textContent = original; }, 2000);
+            }
+        }
+
+        function makeActionBtn(itemId, action, label) {
+            const btn = document.createElement('button');
+            btn.className = `poster-action-btn ${action}`;
+            btn.textContent = label;
+            btn.onclick = (e) => { e.stopPropagation(); itemAction(itemId, action, btn); };
+            return btn;
+        }
+```
+
+- [ ] **Step 2: Render action buttons inside each poster card**
+
+Find this block in the poster card rendering loop (around line 713):
+
+```javascript
+                // Hover badge (shown when viewing prank)
+                if (hasPrank(item.status)) {
+                    const hoverBadge = document.createElement('div');
+                    hoverBadge.className = 'poster-status-prank-hover';
+                    hoverBadge.textContent = 'Viewing Prank';
+                    wrapper.appendChild(hoverBadge);
+                }
+```
+
+Replace it with:
+
+```javascript
+                // Hover badge (shown when viewing prank)
+                if (hasPrank(item.status)) {
+                    const hoverBadge = document.createElement('div');
+                    hoverBadge.className = 'poster-status-prank-hover';
+                    hoverBadge.textContent = 'Viewing Prank';
+                    wrapper.appendChild(hoverBadge);
+                }
+
+                // Per-item action buttons (Apply or Restore)
+                if (item.status === 'PRANK_GENERATED' || item.status === 'PRANK_APPLIED') {
+                    const actions = document.createElement('div');
+                    actions.className = 'poster-item-actions';
+                    if (item.status === 'PRANK_GENERATED') {
+                        actions.appendChild(makeActionBtn(item.item_id, 'apply', 'Apply'));
+                    } else {
+                        actions.appendChild(makeActionBtn(item.item_id, 'restore', 'Restore'));
+                    }
+                    wrapper.appendChild(actions);
+                }
+```
+
+- [ ] **Step 3: Verify the HTML is well-formed (no syntax errors)**
+
+```bash
+python -c "
+from googlarr.web import app
+client = app.test_client()
+resp = client.get('/')
+print('OK' if resp.status_code == 200 else f'ERROR {resp.status_code}')
+"
+```
+
+Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add googlarr/web_ui.html
+git commit -m "feat: render per-item Apply/Restore buttons in poster grid"
+```
+
+---
+
+## Task 4: Rebuild Docker image and verify
+
+- [ ] **Step 1: Push to GitHub**
+
+```bash
+git push origin main
+```
+
+- [ ] **Step 2: Rebuild and restart the container**
+
+```bash
+cd /home/jeremy/GitHub/JPT62089/googlarr
+./googlarr.sh rebuild
+```
+
+- [ ] **Step 3: Verify endpoints exist**
+
+```bash
+sleep 5
+curl -s -X POST http://localhost:8721/api/items/INVALID_ID/apply | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('error', 'unexpected'))"
+```
+
+Expected: `Item not found`
+
+- [ ] **Step 4: Verify web UI loads**
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:8721/
+```
+
+Expected: `200`

--- a/docs/superpowers/specs/2026-04-01-per-item-apply-restore-design.md
+++ b/docs/superpowers/specs/2026-04-01-per-item-apply-restore-design.md
@@ -1,0 +1,51 @@
+# Design: Per-Item Apply/Restore
+
+**Date:** 2026-04-01
+**Status:** Approved
+
+## Summary
+
+Add per-item Apply and Restore buttons to the poster grid in the web UI. Clicking Apply on a poster immediately uploads the prank poster to Emby for that item; clicking Restore uploads the original back. Both actions update the item's DB status and refresh the card's status badge inline.
+
+## Backend
+
+Two new endpoints in `googlarr/web.py`:
+
+```
+POST /api/items/<item_id>/apply
+POST /api/items/<item_id>/restore
+```
+
+Both endpoints:
+1. Load config, call `create_server(config)` to get the adapter
+2. Look up `prank_path` / `original_path` for the item from the SQLite DB
+3. Call `server.upload_poster(item_id, path)`
+4. Call `update_item_status(db, item_id, new_status)` — Apply sets `PRANK_APPLIED`, Restore sets `PRANK_GENERATED`
+5. Return `{"success": true, "status": "<new_status>"}` or `{"success": false, "error": "..."}` with HTTP 500
+
+Return 404 if `item_id` not found in DB. Return 400 if the item has no prank poster on disk (apply only).
+
+## Frontend
+
+In `web_ui.html`, the poster card hover currently shows a prank-preview badge. Add two small buttons at the bottom of the card that appear on hover:
+
+- **Apply** — visible when item status is `PRANK_GENERATED` (prank ready but not live)
+- **Restore** — visible when item status is `PRANK_APPLIED` (prank currently live)
+
+On click:
+1. Button shows a loading state (disabled + spinner text)
+2. POST to the relevant endpoint
+3. On success: update the card's status badge to the new status without reloading the page
+4. On error: show a brief error message on the card
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `googlarr/web.py` | Add `api_item_apply` and `api_item_restore` endpoints |
+| `googlarr/web_ui.html` | Add Apply/Restore hover buttons to poster cards, add JS handlers |
+
+## Out of Scope
+
+- Bulk per-library apply/restore (already exists as "Apply Now" / "Restore Now")
+- Generating the prank poster on demand (item must already be in `PRANK_GENERATED` or `PRANK_APPLIED` state)

--- a/googlarr/apply.py
+++ b/googlarr/apply.py
@@ -1,4 +1,4 @@
-from plexapi.server import PlexServer
+from googlarr.server import create_server
 from googlarr.config import load_config
 from googlarr.prank import apply_pranks, initialize_detector_and_overlay
 
@@ -6,9 +6,9 @@ from googlarr.prank import apply_pranks, initialize_detector_and_overlay
 def main():
     config = load_config()
     initialize_detector_and_overlay(config['detection'])
-    plex = PlexServer(config['plex']['url'], config['plex']['token'])
+    server = create_server(config)
 
-    count = apply_pranks(config, plex)
+    count = apply_pranks(config, server)
     print(f"\nApplied {count} prank poster(s)")
 
 

--- a/googlarr/config.py
+++ b/googlarr/config.py
@@ -9,13 +9,16 @@ def load_config(path='config/config.yml'):
 
 def validate_config(config):
     """Validate config and raise ValueError if invalid."""
-    # Check required Plex keys
-    required_plex_keys = ['url', 'token', 'libraries']
-    if 'plex' not in config:
-        raise ValueError("Missing required key: 'plex'")
-    for key in required_plex_keys:
-        if key not in config['plex']:
-            raise ValueError(f"Missing required key: 'plex.{key}'")
+    # Check required server keys
+    required_server_keys = ['type', 'url', 'token', 'libraries']
+    if 'server' not in config:
+        raise ValueError("Missing required key: 'server'")
+    for key in required_server_keys:
+        if key not in config['server']:
+            raise ValueError(f"Missing required key: 'server.{key}'")
+    valid_types = ('plex', 'emby', 'jellyfin')
+    if config['server']['type'] not in valid_types:
+        raise ValueError(f"'server.type' must be one of: {', '.join(valid_types)}")
 
     # Check required schedule keys
     required_schedule_keys = ['start', 'stop']

--- a/googlarr/db.py
+++ b/googlarr/db.py
@@ -34,26 +34,23 @@ def reset_working_tasks(db_path):
         conn.commit()
 
 
-def sync_library_with_plex(config, plex):
+def sync_library_items(config, server):
 
     originals_dir = config['paths']['originals_dir']
     prank_dir = config['paths']['prank_dir']
 
-    for lib_name in config['plex']['libraries']:
+    for lib_name in config['server']['libraries']:
         print(f"[SYNC] Syncing library: {lib_name}")
-        library = plex.library.section(lib_name)
+        items = server.get_library_items(lib_name)
 
         with sqlite3.connect(config['database']) as conn:
             c = conn.cursor()
 
-            current_ids = set()
-            for item in library.all():
-                item_id = str(item.ratingKey)
-                title = item.title
+            for item in items:
+                item_id = item['item_id']
+                title = item['title']
 
                 print(f"[SYNC] Adding item: {item_id}, {title}, {originals_dir}/{item_id}.jpg, {prank_dir}/{item_id}.jpg")
-
-                current_ids.add(item_id)
 
                 c.execute(
                     "INSERT OR IGNORE INTO library_items (item_id, title, library, original_path, prank_path, status) "
@@ -68,15 +65,10 @@ def sync_library_with_plex(config, plex):
                     )
                 )
 
-                if hasattr(item, 'seasons'):
-                    for season in item.seasons():
-
-                        season_id = str(season.ratingKey)
-                        season_title = f"{item.title} - {season.title}"
-
-                        if not season.thumb:
-                            print(f"[SYNC] Skipping {season_title}: No poster")
-                            continue
+                if item['has_seasons']:
+                    for season in server.get_seasons(item_id):
+                        season_id = season['item_id']
+                        season_title = f"{title} - {season['title']}"
 
                         print(f"[SYNC] Adding season: {season_id}, {season_title}, {originals_dir}/{season_id}.jpg, {prank_dir}/{season_id}.jpg")
 

--- a/googlarr/main.py
+++ b/googlarr/main.py
@@ -6,20 +6,18 @@ import threading
 from datetime import datetime, timedelta
 from croniter import croniter
 
-from plexapi.server import PlexServer
+from googlarr.server import create_server
 from googlarr.config import load_config, validate_config
 from googlarr.db import (
     init_db,
-    sync_library_with_plex,
+    sync_library_items,
     claim_next_poster_task,
     update_item_status,
     get_items_for_update,
     reset_working_tasks
 )
 from googlarr.prank import (
-    download_poster,
     generate_prank_poster,
-    set_poster,
     initialize_detector_and_overlay,
     apply_pranks,
     restore_originals
@@ -49,7 +47,7 @@ def is_prank_active(config):
     return last_on > last_off
 
 
-async def sync_task(config, plex):
+async def sync_task(config, server):
     while True:
         try:
             # Reload config at start of each iteration
@@ -58,9 +56,9 @@ async def sync_task(config, plex):
         except ValueError as e:
             print(f"[SYNC] Config validation failed: {e}. Using previous config.")
 
-        print("[SYNC] Syncing library with Plex...")
+        print("[SYNC] Syncing library...")
         try:
-            sync_library_with_plex(config, plex)
+            sync_library_items(config, server)
         except Exception as e:
             print(f"[SYNC] Sync error: {e}")
 
@@ -81,7 +79,7 @@ async def sync_task(config, plex):
                 sleep_duration -= MAX_SLEEP_SECONDS
 
 
-async def poster_worker(worker_id, config, plex):
+async def poster_worker(worker_id, config, server):
     while True:
         try:
             # Reload config periodically
@@ -111,7 +109,7 @@ async def poster_worker(worker_id, config, plex):
 
         try:
             if item['status'] == 'WORKING_DOWNLOAD':
-                await asyncio.to_thread(download_poster, plex, item, item['original_path'], config)
+                await asyncio.to_thread(server.download_poster, item['item_id'], item['original_path'])
                 update_item_status(config['database'], item['item_id'], 'ORIGINAL_DOWNLOADED')
 
             elif item['status'] == 'WORKING_PRANKIFY':
@@ -126,7 +124,7 @@ async def poster_worker(worker_id, config, plex):
             update_item_status(config['database'], item['item_id'], 'FAILED')
 
 
-async def update_posters_task(config, plex):
+async def update_posters_task(config, server):
     print("[UPDATE] Starting cron-driven poster updater")
 
     # Handle startup state: check if prank window is currently active
@@ -135,11 +133,11 @@ async def update_posters_task(config, plex):
 
     if prank_active:
         print("[UPDATE] Applying any ready pranks from startup...")
-        count = apply_pranks(config, plex)
+        count = apply_pranks(config, server)
         print(f"[UPDATE] Applied {count} prank poster(s) at startup")
     else:
         print("[UPDATE] Restoring any pranked posters from startup...")
-        count = restore_originals(config, plex)
+        count = restore_originals(config, server)
         print(f"[UPDATE] Restored {count} original poster(s) at startup")
 
     while True:
@@ -192,10 +190,10 @@ async def update_posters_task(config, plex):
         now = datetime.now()
         if now >= next_event:
             if action == "apply":
-                count = apply_pranks(config, plex)
+                count = apply_pranks(config, server)
                 print(f"[UPDATE] Applied {count} prank poster(s)")
             else:
-                count = restore_originals(config, plex)
+                count = restore_originals(config, server)
                 print(f"[UPDATE] Restored {count} original poster(s)")
 
 
@@ -219,7 +217,7 @@ async def main():
     init_db(config['database'])
     reset_working_tasks(config['database'])
     initialize_detector_and_overlay(config['detection'])
-    plex = PlexServer(config['plex']['url'], config['plex']['token'])
+    server = create_server(config)
 
     # Start web server in separate thread
     print("[MAIN] Starting web server on port 8721...")
@@ -227,9 +225,9 @@ async def main():
     web_thread.start()
 
     await asyncio.gather(
-        sync_task(config, plex),
-        update_posters_task(config, plex),
-        *[poster_worker(i, config, plex) for i in range(POSTER_WORKERS)]
+        sync_task(config, server),
+        update_posters_task(config, server),
+        *[poster_worker(i, config, server) for i in range(POSTER_WORKERS)]
     )
 
 

--- a/googlarr/prank.py
+++ b/googlarr/prank.py
@@ -1,6 +1,5 @@
 import os
 import cv2
-import requests
 from googlarr.detector import FaceDetector
 from googlarr.overlay import process_image
 from googlarr.db import get_items_for_update, update_item_status
@@ -15,17 +14,6 @@ def initialize_detector_and_overlay(config):
     overlay_img = cv2.imread("assets/eye.png", cv2.IMREAD_UNCHANGED)
 
 
-def download_poster(plex, item, save_path, config):
-    plex_item = plex.fetchItem(int(item['item_id']))
-    url = plex_item.thumbUrl
-    headers = {'Accept': 'image/jpeg'}
-    response = requests.get(url, headers=headers, stream=True)
-    if response.status_code == 200:
-        os.makedirs(os.path.dirname(save_path), exist_ok=True)  # Ensure directory exists
-        with open(save_path, 'wb') as f:
-            for chunk in response.iter_content(1024):
-                f.write(chunk)
-
 def generate_prank_poster(original_path, prank_path, config):
 
     global face_detector, overlay_img
@@ -35,7 +23,6 @@ def generate_prank_poster(original_path, prank_path, config):
         print(f"[PRANK] Failed to read image: {original_path}")
         raise ValueError(f"Failed to read image: {original_path}")
 
-    # Detect eyes using face detector
     eye_locations = face_detector.detect_eyes(img_bgr, config['detection'])
     if not eye_locations:
         print(f"[PRANK] No eyes detected: {original_path}")
@@ -43,7 +30,6 @@ def generate_prank_poster(original_path, prank_path, config):
 
     img_rgb = cv2.cvtColor(img_bgr, cv2.COLOR_BGR2RGB)
 
-    # Apply googly eyes
     try:
         prank_img_rgb = process_image(
             base_image=img_rgb,
@@ -55,29 +41,20 @@ def generate_prank_poster(original_path, prank_path, config):
         print(f"[PRANK] Error applying googly eyes: {e}")
         raise
 
-    # Convert and save
     prank_img_bgr = cv2.cvtColor(prank_img_rgb, cv2.COLOR_RGB2BGR)
     os.makedirs(os.path.dirname(prank_path), exist_ok=True)
     cv2.imwrite(prank_path, prank_img_bgr)
     print(f"[PRANK] Wrote prankified poster to {prank_path}")
 
 
-def set_poster(plex_item, image_path):
-    if not os.path.exists(image_path):
-        raise FileNotFoundError(f"Poster image not found: {image_path}")
-
-    plex_item.uploadPoster(filepath=str(image_path))
-
-
-def apply_pranks(config, plex) -> int:
+def apply_pranks(config, server) -> int:
     """Apply prank posters to all PRANK_GENERATED items. Returns count applied."""
     items = get_items_for_update(config['database'])
     count = 0
     for item in items:
         if item['status'] == 'PRANK_GENERATED':
             try:
-                plex_item = plex.fetchItem(int(item['item_id']))
-                set_poster(plex_item, item['prank_path'])
+                server.upload_poster(item['item_id'], item['prank_path'])
                 update_item_status(config['database'], item['item_id'], 'PRANK_APPLIED')
                 print(f"[APPLY] Applied prank poster to {item['title']}")
                 count += 1
@@ -87,15 +64,14 @@ def apply_pranks(config, plex) -> int:
     return count
 
 
-def restore_originals(config, plex) -> int:
+def restore_originals(config, server) -> int:
     """Restore original posters for all PRANK_APPLIED items. Returns count restored."""
     items = get_items_for_update(config['database'])
     count = 0
     for item in items:
         if item['status'] == 'PRANK_APPLIED':
             try:
-                plex_item = plex.fetchItem(int(item['item_id']))
-                set_poster(plex_item, item['original_path'])
+                server.upload_poster(item['item_id'], item['original_path'])
                 update_item_status(config['database'], item['item_id'], 'PRANK_GENERATED')
                 print(f"[RESTORE] Restored original poster for {item['title']}")
                 count += 1
@@ -103,4 +79,3 @@ def restore_originals(config, plex) -> int:
                 update_item_status(config['database'], item['item_id'], 'FAILED')
                 print(f"[RESTORE] Error restoring original for {item['title']}: {e}")
     return count
-

--- a/googlarr/regenerate.py
+++ b/googlarr/regenerate.py
@@ -1,53 +1,43 @@
 import sys
 import traceback
 import os
-from plexapi.server import PlexServer
+from googlarr.server import create_server
 from googlarr.config import load_config
 from googlarr.prank import (
     initialize_detector_and_overlay,
     generate_prank_poster,
-    download_poster
 )
 from googlarr.db import update_item_status
 
 def main():
     if len(sys.argv) != 2:
-        print("Usage: python -m googlarr.regenerate <ratingKey>")
+        print("Usage: python -m googlarr.regenerate <item_id>")
         sys.exit(1)
 
-    rating_key = sys.argv[1]
+    item_id = sys.argv[1]
     config = load_config()
     initialize_detector_and_overlay(config['detection'])
-    plex = PlexServer(config['plex']['url'], config['plex']['token'])
+    server = create_server(config)
 
-    # Find the item by ID
-    try:
-        item = plex.fetchItem(int(rating_key))
-    except Exception as e:
-        print(f"Failed to find item with ratingKey {rating_key}: {e}")
-        sys.exit(1)
-
-    title = item.title
-    item_id = str(item.ratingKey)
     original_path = f"{config['paths']['originals_dir']}/{item_id}.jpg"
     prank_path = f"{config['paths']['prank_dir']}/{item_id}.jpg"
 
     try:
         # Download original if missing
         if not os.path.exists(original_path):
-            print(f"Downloading original poster for '{title}'...")
-            download_poster(plex, {'item_id': item_id}, original_path, config)
+            print(f"Downloading original poster for item {item_id}...")
+            server.download_poster(item_id, original_path)
             update_item_status(config['database'], item_id, 'ORIGINAL_DOWNLOADED')
 
         # Regenerate prank
-        print(f"Generating prank poster for '{title}'...")
+        print(f"Generating prank poster for item {item_id}...")
         generate_prank_poster(original_path, prank_path, config)
         update_item_status(config['database'], item_id, 'PRANK_GENERATED')
 
         print(f"Done. Prank poster saved to {prank_path}")
     except Exception as e:
         tb = traceback.format_exc()
-        print(f"Error processing {title}: {e.__class__.__name__}: {e}")
+        print(f"Error processing item {item_id}: {e.__class__.__name__}: {e}")
         print(tb)
 
         update_item_status(config['database'], item_id, 'FAILED')
@@ -55,4 +45,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/googlarr/restore.py
+++ b/googlarr/restore.py
@@ -1,4 +1,4 @@
-from plexapi.server import PlexServer
+from googlarr.server import create_server
 from googlarr.config import load_config
 from googlarr.prank import restore_originals, initialize_detector_and_overlay
 
@@ -6,9 +6,9 @@ from googlarr.prank import restore_originals, initialize_detector_and_overlay
 def main():
     config = load_config()
     initialize_detector_and_overlay(config['detection'])
-    plex = PlexServer(config['plex']['url'], config['plex']['token'])
+    server = create_server(config)
 
-    count = restore_originals(config, plex)
+    count = restore_originals(config, server)
     print(f"\nRestored {count} original poster(s)")
 
 

--- a/googlarr/server/__init__.py
+++ b/googlarr/server/__init__.py
@@ -1,3 +1,16 @@
 from googlarr.server.base import MediaServer
+from googlarr.server.plex import PlexAdapter
+from googlarr.server.emby import EmbyAdapter
 
-__all__ = ['MediaServer']
+
+def create_server(config: dict) -> MediaServer:
+    server_type = config['server']['type']
+    if server_type == 'plex':
+        return PlexAdapter(config)
+    elif server_type in ('emby', 'jellyfin'):
+        return EmbyAdapter(config)
+    else:
+        raise ValueError(f"Unknown server type: {server_type!r}. Must be one of: plex, emby, jellyfin")
+
+
+__all__ = ['MediaServer', 'create_server']

--- a/googlarr/server/__init__.py
+++ b/googlarr/server/__init__.py
@@ -1,0 +1,3 @@
+from googlarr.server.base import MediaServer
+
+__all__ = ['MediaServer']

--- a/googlarr/server/base.py
+++ b/googlarr/server/base.py
@@ -1,0 +1,19 @@
+from typing import Protocol
+
+
+class MediaServer(Protocol):
+    def get_library_items(self, library_name: str) -> list[dict]:
+        """Return list of {item_id: str, title: str, has_seasons: bool}."""
+        ...
+
+    def get_seasons(self, item_id: str) -> list[dict]:
+        """Return list of {item_id: str, title: str} for seasons that have a poster."""
+        ...
+
+    def download_poster(self, item_id: str, save_path: str) -> None:
+        """Download the primary poster for item_id and save to save_path."""
+        ...
+
+    def upload_poster(self, item_id: str, image_path: str) -> None:
+        """Upload the image at image_path as the primary poster for item_id."""
+        ...

--- a/googlarr/server/emby.py
+++ b/googlarr/server/emby.py
@@ -1,0 +1,82 @@
+import os
+import requests
+
+
+class EmbyAdapter:
+    def __init__(self, config: dict):
+        self._base_url = config['server']['url'].rstrip('/')
+        self._token = config['server']['token']
+        self._headers = {'X-Emby-Token': self._token}
+
+        resp = requests.get(f"{self._base_url}/Users/Me", headers=self._headers)
+        resp.raise_for_status()
+        self._user_id = resp.json()['Id']
+
+    def _get_library_id(self, library_name: str) -> str:
+        resp = requests.get(f"{self._base_url}/Library/VirtualFolders", headers=self._headers)
+        resp.raise_for_status()
+        for folder in resp.json():
+            if folder['Name'] == library_name:
+                return folder['ItemId']
+        raise ValueError(f"Library not found: {library_name}")
+
+    def get_library_items(self, library_name: str) -> list[dict]:
+        library_id = self._get_library_id(library_name)
+        resp = requests.get(
+            f"{self._base_url}/Users/{self._user_id}/Items",
+            headers=self._headers,
+            params={
+                'ParentId': library_id,
+                'Recursive': 'true',
+                'IncludeItemTypes': 'Movie,Series',
+            }
+        )
+        resp.raise_for_status()
+        items = []
+        for item in resp.json().get('Items', []):
+            items.append({
+                'item_id': item['Id'],
+                'title': item['Name'],
+                'has_seasons': item['Type'] == 'Series',
+            })
+        return items
+
+    def get_seasons(self, item_id: str) -> list[dict]:
+        resp = requests.get(
+            f"{self._base_url}/Shows/{item_id}/Seasons",
+            headers=self._headers,
+            params={'UserId': self._user_id}
+        )
+        resp.raise_for_status()
+        seasons = []
+        for season in resp.json().get('Items', []):
+            if season.get('ImageTags', {}).get('Primary'):
+                seasons.append({
+                    'item_id': season['Id'],
+                    'title': season['Name'],
+                })
+        return seasons
+
+    def download_poster(self, item_id: str, save_path: str) -> None:
+        resp = requests.get(
+            f"{self._base_url}/Items/{item_id}/Images/Primary",
+            headers=self._headers,
+            stream=True
+        )
+        resp.raise_for_status()
+        os.makedirs(os.path.dirname(save_path), exist_ok=True)
+        with open(save_path, 'wb') as f:
+            for chunk in resp.iter_content(1024):
+                f.write(chunk)
+
+    def upload_poster(self, item_id: str, image_path: str) -> None:
+        if not os.path.exists(image_path):
+            raise FileNotFoundError(f"Poster image not found: {image_path}")
+        with open(image_path, 'rb') as f:
+            image_data = f.read()
+        resp = requests.post(
+            f"{self._base_url}/Items/{item_id}/Images/Primary",
+            headers={**self._headers, 'Content-Type': 'image/jpeg'},
+            data=image_data
+        )
+        resp.raise_for_status()

--- a/googlarr/server/emby.py
+++ b/googlarr/server/emby.py
@@ -1,3 +1,4 @@
+import base64
 import os
 import requests
 
@@ -80,7 +81,7 @@ class EmbyAdapter:
         if not os.path.exists(image_path):
             raise FileNotFoundError(f"Poster image not found: {image_path}")
         with open(image_path, 'rb') as f:
-            image_data = f.read()
+            image_data = base64.b64encode(f.read()).decode('utf-8')
         resp = requests.post(
             f"{self._base_url}/Items/{item_id}/Images/Primary",
             headers={**self._headers, 'Content-Type': 'image/jpeg'},

--- a/googlarr/server/emby.py
+++ b/googlarr/server/emby.py
@@ -9,8 +9,15 @@ class EmbyAdapter:
         self._headers = {'X-Emby-Token': self._token}
 
         resp = requests.get(f"{self._base_url}/Users/Me", headers=self._headers)
-        resp.raise_for_status()
-        self._user_id = resp.json()['Id']
+        if resp.ok:
+            self._user_id = resp.json()['Id']
+        else:
+            # Some Emby versions return 500 for /Users/Me with API keys; fall back to /Users
+            resp = requests.get(f"{self._base_url}/Users", headers=self._headers)
+            resp.raise_for_status()
+            users = resp.json()
+            admin = next((u for u in users if u.get('Policy', {}).get('IsAdministrator')), users[0])
+            self._user_id = admin['Id']
 
     def _get_library_id(self, library_name: str) -> str:
         resp = requests.get(f"{self._base_url}/Library/VirtualFolders", headers=self._headers)

--- a/googlarr/server/plex.py
+++ b/googlarr/server/plex.py
@@ -14,7 +14,7 @@ class PlexAdapter:
             items.append({
                 'item_id': str(item.ratingKey),
                 'title': item.title,
-                'has_seasons': hasattr(item, 'seasons'),
+                'has_seasons': item.TYPE == 'show',
             })
         return items
 

--- a/googlarr/server/plex.py
+++ b/googlarr/server/plex.py
@@ -1,0 +1,46 @@
+import os
+import requests
+from plexapi.server import PlexServer
+
+
+class PlexAdapter:
+    def __init__(self, config: dict):
+        self._plex = PlexServer(config['server']['url'], config['server']['token'])
+
+    def get_library_items(self, library_name: str) -> list[dict]:
+        library = self._plex.library.section(library_name)
+        items = []
+        for item in library.all():
+            items.append({
+                'item_id': str(item.ratingKey),
+                'title': item.title,
+                'has_seasons': hasattr(item, 'seasons'),
+            })
+        return items
+
+    def get_seasons(self, item_id: str) -> list[dict]:
+        item = self._plex.fetchItem(int(item_id))
+        seasons = []
+        for season in item.seasons():
+            if season.thumb:
+                seasons.append({
+                    'item_id': str(season.ratingKey),
+                    'title': season.title,
+                })
+        return seasons
+
+    def download_poster(self, item_id: str, save_path: str) -> None:
+        item = self._plex.fetchItem(int(item_id))
+        url = item.thumbUrl
+        response = requests.get(url, headers={'Accept': 'image/jpeg'}, stream=True)
+        response.raise_for_status()
+        os.makedirs(os.path.dirname(save_path), exist_ok=True)
+        with open(save_path, 'wb') as f:
+            for chunk in response.iter_content(1024):
+                f.write(chunk)
+
+    def upload_poster(self, item_id: str, image_path: str) -> None:
+        if not os.path.exists(image_path):
+            raise FileNotFoundError(f"Poster image not found: {image_path}")
+        item = self._plex.fetchItem(int(item_id))
+        item.uploadPoster(filepath=str(image_path))

--- a/googlarr/web.py
+++ b/googlarr/web.py
@@ -199,6 +199,68 @@ def api_poster_prank(item_id):
     return send_file(prank_path, mimetype='image/jpeg')
 
 
+@app.route('/api/items/<item_id>/apply', methods=['POST'])
+def api_item_apply(item_id):
+    """Apply prank poster to a single item immediately."""
+    config = get_config()
+    db_path = get_db()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        c = conn.cursor()
+        c.execute("SELECT * FROM library_items WHERE item_id = ?", (item_id,))
+        item = c.fetchone()
+
+    if not item:
+        return jsonify({'success': False, 'error': 'Item not found'}), 404
+
+    item = dict(item)
+    prank_path = os.path.join(APP_ROOT, item['prank_path'])
+    if not os.path.exists(prank_path):
+        return jsonify({'success': False, 'error': 'Prank poster not generated yet'}), 400
+
+    try:
+        from googlarr.server import create_server
+        from googlarr.db import update_item_status
+        server = create_server(config)
+        server.upload_poster(item_id, prank_path)
+        update_item_status(db_path, item_id, 'PRANK_APPLIED')
+        return jsonify({'success': True, 'status': 'PRANK_APPLIED'})
+    except Exception as e:
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@app.route('/api/items/<item_id>/restore', methods=['POST'])
+def api_item_restore(item_id):
+    """Restore original poster for a single item immediately."""
+    config = get_config()
+    db_path = get_db()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        c = conn.cursor()
+        c.execute("SELECT * FROM library_items WHERE item_id = ?", (item_id,))
+        item = c.fetchone()
+
+    if not item:
+        return jsonify({'success': False, 'error': 'Item not found'}), 404
+
+    item = dict(item)
+    original_path = os.path.join(APP_ROOT, item['original_path'])
+    if not os.path.exists(original_path):
+        return jsonify({'success': False, 'error': 'Original poster not found'}), 400
+
+    try:
+        from googlarr.server import create_server
+        from googlarr.db import update_item_status
+        server = create_server(config)
+        server.upload_poster(item_id, original_path)
+        update_item_status(db_path, item_id, 'PRANK_GENERATED')
+        return jsonify({'success': True, 'status': 'PRANK_GENERATED'})
+    except Exception as e:
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
 @app.route('/api/apply-now', methods=['POST'])
 def api_apply_now():
     """Override: Apply all PRANK_GENERATED items immediately."""

--- a/googlarr/web.py
+++ b/googlarr/web.py
@@ -215,6 +215,8 @@ def api_item_apply(item_id):
         return jsonify({'success': False, 'error': 'Item not found'}), 404
 
     item = dict(item)
+    if not item.get('prank_path'):
+        return jsonify({'success': False, 'error': 'Prank poster not generated yet'}), 400
     prank_path = os.path.join(APP_ROOT, item['prank_path'])
     if not os.path.exists(prank_path):
         return jsonify({'success': False, 'error': 'Prank poster not generated yet'}), 400
@@ -246,6 +248,8 @@ def api_item_restore(item_id):
         return jsonify({'success': False, 'error': 'Item not found'}), 404
 
     item = dict(item)
+    if not item.get('original_path'):
+        return jsonify({'success': False, 'error': 'Original poster not found'}), 400
     original_path = os.path.join(APP_ROOT, item['original_path'])
     if not os.path.exists(original_path):
         return jsonify({'success': False, 'error': 'Original poster not found'}), 400

--- a/googlarr/web.py
+++ b/googlarr/web.py
@@ -103,7 +103,7 @@ def api_libraries():
     libraries = []
     with sqlite3.connect(db_path) as conn:
         c = conn.cursor()
-        for lib_name in config['plex']['libraries']:
+        for lib_name in config['server']['libraries']:
             c.execute("SELECT COUNT(*) FROM library_items WHERE library = ?", (lib_name,))
             count = c.fetchone()[0]
             libraries.append({
@@ -204,9 +204,9 @@ def api_apply_now():
     """Override: Apply all PRANK_GENERATED items immediately."""
     config = get_config()
     try:
-        from plexapi.server import PlexServer
-        plex = PlexServer(config['plex']['url'], config['plex']['token'])
-        count = apply_pranks(config, plex)
+        from googlarr.server import create_server
+        server = create_server(config)
+        count = apply_pranks(config, server)
         return jsonify({
             'success': True,
             'applied_count': count,
@@ -224,9 +224,9 @@ def api_restore_now():
     """Override: Restore all PRANK_APPLIED items immediately."""
     config = get_config()
     try:
-        from plexapi.server import PlexServer
-        plex = PlexServer(config['plex']['url'], config['plex']['token'])
-        count = restore_originals(config, plex)
+        from googlarr.server import create_server
+        server = create_server(config)
+        count = restore_originals(config, server)
         return jsonify({
             'success': True,
             'restored_count': count,

--- a/googlarr/web_ui.html
+++ b/googlarr/web_ui.html
@@ -633,6 +633,54 @@
             document.getElementById('lastUpdated').textContent = formatTime(data.last_updated);
         }
 
+        async function itemAction(itemId, action, btn) {
+            btn.disabled = true;
+            const original = btn.textContent;
+            btn.textContent = '...';
+            try {
+                const resp = await fetch(`${API_BASE}/items/${itemId}/${action}`, { method: 'POST' });
+                const data = await resp.json();
+                if (data.success) {
+                    // Update the status badge on this card
+                    const card = btn.closest('.poster-item');
+                    const badge = card.querySelector('.poster-status');
+                    const statusConfig = {
+                        'PRANK_APPLIED':   { cls: 'status-prank-live',  label: 'Live' },
+                        'PRANK_GENERATED': { cls: 'status-prank-ready', label: 'Ready' },
+                    };
+                    const cfg = statusConfig[data.status];
+                    if (cfg && badge) {
+                        badge.className = `poster-status ${cfg.cls}`;
+                        badge.textContent = cfg.label;
+                    }
+                    // Swap which button is visible
+                    const actions = card.querySelector('.poster-item-actions');
+                    if (actions) {
+                        actions.innerHTML = '';
+                        if (data.status === 'PRANK_GENERATED') {
+                            actions.appendChild(makeActionBtn(itemId, 'apply', 'Apply'));
+                        } else if (data.status === 'PRANK_APPLIED') {
+                            actions.appendChild(makeActionBtn(itemId, 'restore', 'Restore'));
+                        }
+                    }
+                } else {
+                    btn.textContent = 'Error';
+                    setTimeout(() => { btn.disabled = false; btn.textContent = original; }, 2000);
+                }
+            } catch (e) {
+                btn.textContent = 'Error';
+                setTimeout(() => { btn.disabled = false; btn.textContent = original; }, 2000);
+            }
+        }
+
+        function makeActionBtn(itemId, action, label) {
+            const btn = document.createElement('button');
+            btn.className = `poster-action-btn ${action}`;
+            btn.textContent = label;
+            btn.onclick = (e) => { e.stopPropagation(); itemAction(itemId, action, btn); };
+            return btn;
+        }
+
         async function applyNow() {
             if (!confirm('Apply pranks to all PRANK_GENERATED items?')) return;
             const res = await fetch(`${API_BASE}/apply-now`, { method: 'POST' });
@@ -768,6 +816,18 @@
                     hoverBadge.className = 'poster-status-prank-hover';
                     hoverBadge.textContent = 'Viewing Prank';
                     wrapper.appendChild(hoverBadge);
+                }
+
+                // Per-item action buttons (Apply or Restore)
+                if (item.status === 'PRANK_GENERATED' || item.status === 'PRANK_APPLIED') {
+                    const actions = document.createElement('div');
+                    actions.className = 'poster-item-actions';
+                    if (item.status === 'PRANK_GENERATED') {
+                        actions.appendChild(makeActionBtn(item.item_id, 'apply', 'Apply'));
+                    } else {
+                        actions.appendChild(makeActionBtn(item.item_id, 'restore', 'Restore'));
+                    }
+                    wrapper.appendChild(actions);
                 }
 
                 const title = document.createElement('div');

--- a/googlarr/web_ui.html
+++ b/googlarr/web_ui.html
@@ -315,6 +315,58 @@
         .poster-item.has-prank:hover .poster-status { opacity: 0; transition: opacity 0.3s ease; }
         .poster-item.has-prank:hover .poster-status-prank-hover { opacity: 1; }
 
+        .poster-item-actions {
+            position: absolute;
+            bottom: 28px;
+            left: 0; right: 0;
+            display: flex;
+            justify-content: center;
+            gap: 6px;
+            z-index: 5;
+            opacity: 0;
+            transition: opacity 0.2s ease;
+            padding: 0 6px;
+        }
+
+        .poster-item:hover .poster-item-actions {
+            opacity: 1;
+        }
+
+        .poster-action-btn {
+            font-size: 10px;
+            font-weight: 700;
+            padding: 3px 8px;
+            border: none;
+            border-radius: 3px;
+            cursor: pointer;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            white-space: nowrap;
+        }
+
+        .poster-action-btn.apply {
+            background: rgba(33, 150, 243, 0.92);
+            color: #fff;
+        }
+
+        .poster-action-btn.apply:hover {
+            background: rgba(33, 150, 243, 1);
+        }
+
+        .poster-action-btn.restore {
+            background: rgba(76, 175, 80, 0.92);
+            color: #fff;
+        }
+
+        .poster-action-btn.restore:hover {
+            background: rgba(76, 175, 80, 1);
+        }
+
+        .poster-action-btn:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
         .poster-placeholder {
             position: absolute;
             top: 0; left: 0; right: 0; bottom: 0;


### PR DESCRIPTION
## Summary

- **Multi-backend support**: Adds an adapter pattern (`MediaServer` protocol) so googlarr works with Plex, Emby, and Jellyfin. One backend per instance, configured via `config.yml`.
- **EmbyAdapter**: Full Emby/Jellyfin implementation using raw `requests` — library listing, item enumeration, season detection, poster download/upload (base64-encoded as Emby requires).
- **Per-item Apply/Restore**: Hover buttons on each poster card let you push a single prank poster to the server or restore the original immediately, without waiting for the scheduled cron window.

## What changed

| Area | Details |
|---|---|
| `googlarr/server/` | New package: `base.py` (Protocol), `plex.py` (PlexAdapter), `emby.py` (EmbyAdapter), `__init__.py` (factory) |
| `googlarr/config.py` | Validates `server.type/url/token/libraries` instead of `plex.*` |
| `googlarr/db.py` | `sync_library_items()` uses adapter instead of plexapi directly |
| `googlarr/prank.py` | `apply_pranks`/`restore_originals` take `server` param, call `server.upload_poster()` |
| `googlarr/main.py` | Uses `create_server(config)` factory |
| `googlarr/web.py` | Two new endpoints: `POST /api/items/<id>/apply` and `/restore` |
| `googlarr/web_ui.html` | Hover action buttons (Apply/Restore) on poster cards with inline status update |
| Legacy scripts | `apply.py`, `restore.py`, `regenerate.py` updated to use adapter |
| Config | `server.type` field (`plex`, `emby`, `jellyfin`) replaces `plex.*` block |

## Config change

```yaml
# Before
plex:
  url: "http://localhost:32400"
  token: "your-token"

# After
server:
  type: "emby"        # plex | emby | jellyfin
  url: "https://your-server"
  token: "your-token"
  libraries:
    - "Movies"
    - "TV shows"
```

## Test plan

- [x] Emby: library scan, poster download, prank generation, apply, restore
- [x] Per-item apply/restore via web UI hover buttons
- [x] Docker build and run
- [ ] Plex: existing functionality preserved (PlexAdapter wraps plexapi unchanged)
- [ ] Jellyfin: should work identically to Emby (same REST API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)